### PR TITLE
Add comments to editor code

### DIFF
--- a/defold-simpledata/editor/src/simpledata-ext.clj
+++ b/defold-simpledata/editor/src/simpledata-ext.clj
@@ -22,42 +22,62 @@
 
 (set! *warn-on-reflection* true)
 
-(def ^:private simpledata-icon "/defold-simpledata/editor/resources/icons/Icon-SimpleData.png")
 (def ^:private simpledata-ext "simpledata")
+(def ^:private simpledata-icon "/defold-simpledata/editor/resources/icons/Icon-SimpleData.png")
+(def ^:private simpledata-template "/defold-simpledata/editor/resources/templates/template.simpledata")
 
 (def ^:private simpledata-plugin-desc-cls
   (delay (workspace/load-class! "com.dynamo.simpledata.proto.SimpleData$SimpleDataDesc")))
 
 ;;//////////////////////////////////////////////////////////////////////////////////////////////
 
-(defn- set-form-op [{:keys [node-id]} [property] value]
-  (g/set-property! node-id property value))
-
-(defn- clear-form-op [{:keys [node-id]} [property]]
-  (g/clear-property! node-id property))
-
-(defn- validate-property [node-id prop-kw validate-fn value]
+(defn- validate-property
+  "Helper function for property validation. Applies the supplied validate-fn to
+  the value and the property name, and returns an ErrorValue in case it returns
+  a non-nil string expressing a problem with the value."
+  [prop-kw validate-fn node-id value]
   (validation/prop-error :fatal node-id prop-kw validate-fn value (validation/keyword->name prop-kw)))
 
+(defn- prop-non-empty?
+  "Property validate-fn for use with the validate-property function. Takes a
+  property value and the name of the property. Is expected to test the validity
+  of the property value, and return a string describing the problem in case the
+  value is not valid. For valid values, it should return nil."
+  [value prop-name]
+  (when (empty? value)
+    (format "'%s' must be specified" prop-name)))
+
 (defn- validate-name [node-id value]
-  (validate-property node-id :name validation/prop-empty? value))
+  (validate-property :name prop-non-empty? node-id value))
 
 (defn- validate-f32 [node-id value]
-  (validate-property node-id :f32 validation/prop-1-1? value))
+  (validate-property :f32 validation/prop-1-1? node-id value))
 
 (defn- validate-u32 [node-id value]
-  (validate-property node-id :u32 validation/prop-negative? value))
+  (validate-property :u32 validation/prop-negative? node-id value))
 
 (defn- validate-u64 [node-id value]
-  (validate-property node-id :u64 validation/prop-negative? value))
+  (validate-property :u64 validation/prop-negative? node-id value))
 
-(defn- build-simpledata [resource _dep-resources user-data]
+(defn- build-simpledata
+  "Build function embedded in the build targets for SimpleData. Once build
+  targets have been gathered, this function will be called with a BuildResource
+  (for output), and the user-data from a SimpleData build target produced by the
+  produce-build-targets defnk. It is expected to return a map containing the
+  BuildResource and the content that should be written to it as a byte array."
+  [resource _dep-resources user-data]
   (let [simpledata-pb (:simpledata-pb user-data)
         content (protobuf/map->bytes @simpledata-plugin-desc-cls simpledata-pb)]
     {:resource resource
      :content content}))
 
-(g/defnk produce-build-targets [_node-id resource simpledata-pb build-errors]
+(g/defnk produce-build-targets
+  "Produce the build targets for a single SimpleData resource. Each SimpleData
+  resource results in one binary resource for the engine runtime. The contents
+  of the build target are hashed and used to determine if we need to re-run the
+  build-fn and write a new file. If there are build errors, return an ErrorValue
+  that will abort the build and report the errors to the Build Errors pane."
+  [_node-id resource simpledata-pb build-errors]
   (g/precluding-errors build-errors
     [(bt/with-content-hash
        {:node-id _node-id
@@ -65,11 +85,35 @@
         :build-fn build-simpledata
         :user-data {:simpledata-pb simpledata-pb}})]))
 
-(g/defnk produce-form-data [_node-id name f32 u32 i32 u64 i64]
+(defn- set-form-op!
+  "Callback invoked by the form view when a value is edited by the user. Is
+  expected to perform the relevant changes to the graph. In our case, we simply
+  set the value of the property on the edited SimpleDataNode."
+  [user-data property-path value]
+  (assert (= 1 (count property-path)))
+  (let [node-id (:node-id user-data)
+        prop-kw (first property-path)]
+    (g/set-property! node-id prop-kw value)))
+
+(defn- clear-form-op!
+  "Callback invoked by the form view when a value is cleared (or reset), by the
+  user. Is expected to perform the relevant changes to the graph. In our case,
+  we simply clear the value of the property on the edited SimpleDataNode."
+  [user-data property-path]
+  (assert (= 1 (count property-path)))
+  (let [node-id (:node-id user-data)
+        prop-kw (first property-path)]
+    (g/clear-property! node-id prop-kw)))
+
+(g/defnk produce-form-data
+  "Produce form-data for editing SimpleData using the form view. This can be
+  used to open standalone SimpleData resources in an editor tab. The form view
+  will render a simple user-interface based on the data we return here."
+  [_node-id name f32 u32 i32 u64 i64]
   {:navigation false
    :form-ops {:user-data {:node-id _node-id}
-              :set set-form-op
-              :clear clear-form-op}
+              :set set-form-op!
+              :clear clear-form-op!}
    :sections [{:title "SimpleData"
                :fields [{:path [:name]
                          :label "Name"
@@ -96,7 +140,11 @@
             [:u64] u64
             [:i64] i64}})
 
-(g/defnk produce-simpledata-pb [name f32 u32 i32 u64 i64]
+(g/defnk produce-simpledata-pb
+  "Produce a Clojure map representation of the protobuf field values that can be
+  saved to disk in protobuf text format, or built into a binary protobuf message
+  for the engine runtime."
+  [name f32 u32 i32 u64 i64]
   {:name name
    :f32 f32
    :u32 u32
@@ -104,7 +152,11 @@
    :u64 u64
    :i64 i64})
 
-(g/defnk produce-build-errors [_node-id name f32 u32 u64]
+(g/defnk produce-build-errors
+  "Produce an ErrorPackage of one or more ErrorValues that express problems with
+  our SimpleData. If there are no errors, produce nil. Any errors produced here
+  will be reported as clickable errors in the Build Errors view."
+  [_node-id name f32 u32 u64]
   (g/package-errors
     _node-id
     (validate-name _node-id name)
@@ -112,7 +164,14 @@
     (validate-u32 _node-id u32)
     (validate-u64 _node-id u64)))
 
-(defn- load-simpledata [_project self _resource data]
+(defn- load-simpledata
+  "After a SimpleDataNode has been created for our SimpleData resource, this
+  function is called with our self node-id and a Clojure map representation of
+  the protobuf data read from our resource. We're expected to return a sequence
+  of transaction steps that populate our SimpleDataNode from the protobuf data.
+  In our case, that simply means setting the property values on our node to the
+  values from the protobuf data."
+  [_project self _resource data]
   (g/set-property
     self
     :name (:name data)
@@ -122,13 +181,23 @@
     :u64 (:u64 data)
     :i64 (:i64 data)))
 
-(g/defnk produce-node-outline [_node-id]
+(g/defnk produce-node-outline
+  "Produce node outline data for displaying our SimpleData in the outline view
+  tree hierarchy. If there are errors, apply a red coloring to our entry."
+  [_node-id build-errors]
   {:node-id _node-id
-   :node-outline-key "SimpleData"
-   :label "SimpleData"
-   :icon simpledata-icon})
+   :node-outline-key simpledata-ext
+   :label "Simple Data"
+   :icon simpledata-icon
+   :outline-error? (g/error-fatal? build-errors)})
 
 (g/defnode SimpleDataNode
+  "Defines a node type that will represent SimpleData resources in the graph.
+  Whenever we encounter a .simpledata file in the project, a SimpleDataNode is
+  created for it, and the load-fn we register for the resource type will be run
+  to populate the SimpleDataNode from the protobuf data. We implement a series
+  of named outputs to make it possible to edit the node using the form view,
+  save changes, build binaries for the engine runtime, and so on."
   (inherits resource-node/ResourceNode)
 
   ;; Editable properties.
@@ -161,7 +230,17 @@
 
 ;;//////////////////////////////////////////////////////////////////////////////////////////////
 
-(defn- register-resource-types [workspace]
+(defn- register-resource-types
+  "Register our .simpledata resource type with the workspace. Whenever we find
+  a .simpledata file in the project, a SimpleDataNode is created for it. Then,
+  the load-fn populates the SimpleDataNode from a Clojure map representation of
+  the protobuf data we load from the .simpledata resource. When we register our
+  resource type, we also tag ourselves as a component that can be used in game
+  objects, and declare which view types can present our resource for editing in
+  an editor tab. In our case, we will use the form view for editing. To work
+  with the form view, our node is expected to implement the form-data output
+  required by the form view."
+  [workspace]
   (resource-node/register-ddf-resource-type
     workspace
     :ext simpledata-ext
@@ -174,7 +253,7 @@
     :view-opts {}
     :tags #{:component}
     :tag-opts {:component {:transform-properties #{}}}
-    :template "/defold-simpledata/editor/resources/templates/template.simpledata"))
+    :template simpledata-template))
 
 ;; The plugin
 (defn- load-plugin-simpledata [workspace]


### PR DESCRIPTION
### Technical changes
* Added `def` for `simpledata-template`.
* Added comments to editor code.
* Added `prop-non-empty?` function as an example of a custom property `validate-fn`.
* Changed argument order for the `validate-property` function.
* Removed unnecessary override of `node-outline` output.
* Rewrote `set-form-op!` and `clear-form-op!` to be simpler and easier to follow.