### PR TITLE
Update to Defold 1.9.6

### DIFF
--- a/defold-simpledata/pluginsrc/com/defold/bob/pipeline/SimpleDataBuilder.java
+++ b/defold-simpledata/pluginsrc/com/defold/bob/pipeline/SimpleDataBuilder.java
@@ -26,7 +26,7 @@ import com.dynamo.simpledata.proto.SimpleData.SimpleDataDesc;
 public class SimpleDataBuilder extends ProtoBuilder<SimpleDataDesc.Builder> {
 
     @Override
-    protected SimpleDataDesc.Builder transform(Task<Void> task, IResource resource, SimpleDataDesc.Builder builder) throws CompileExceptionError {
+    protected SimpleDataDesc.Builder transform(Task task, IResource resource, SimpleDataDesc.Builder builder) throws CompileExceptionError {
         // Add any transforms here
         return builder;
     }


### PR DESCRIPTION
It looks like Defold 1.9.5 or 1.9.6 has changed the Java API a bit. This PR fixes that.

Fixes https://github.com/defold/extension-simpledata/issues/13